### PR TITLE
add a check against the user DB before muting with trolloll

### DIFF
--- a/Shiba.js
+++ b/Shiba.js
@@ -485,7 +485,7 @@ Shiba.prototype.onCmdSeen = function*(msg, user) {
     return;
   }
 
-  if (profanity[user]) {
+  if (Lib.isInvalidUsername(user) == false && profanity[user] == true) {
     doSay('so trollol. very annoying. such mute');
     this.webClient.doMute(msg.username, '5m', msg.channelName);
     return;


### PR DESCRIPTION
I believe this will prevent any user who has one of the names on the profanity list from getting muted when someone does a !s command on them 

i'm not sure exactly how i would go about testing this, so looking to you guys @RHavar and @kungfuant for a little bit of guidance if this was the right change that needed to be made here 

also, i couldnt remember if JS worked with the ! operator for == false so i added it explicitly, let me know if you prefer a different style for the conditional i changed 