### PR TITLE
Update Urban.js - Incorrect URL format

### DIFF
--- a/Cmd/Urban.js
+++ b/Cmd/Urban.js
@@ -59,7 +59,7 @@ Urban.prototype.handle = function*(client, msg, input) {
         numChars += line.length;
       } else {
         const url =
-          'https://urbandictionary.com/define?term=' +
+          'http://urbandictionary.com/define.php?term=' +
           encodeURIComponent(input);
         client.doSay(line + ' ...', msg.channelName);
         client.doSay('Full definition: ' + url, msg.channelName);


### PR DESCRIPTION
I found that the URL of urban dictionary doesnt work as it is (for me).

So here is the pull request for that.